### PR TITLE
Fix python 3.6 travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
   matrix:
     - python=2.7  CONDA_PY=2.7
     - python=3.5  CONDA_PY=3.5
-    - python=3.5  CONDA_PY=3.6
+    - python=3.6  CONDA_PY=3.6
 
   global:
     - ORGNAME="omnia"


### PR DESCRIPTION
This PR fixes an inconsistency in the travis build matrix that was causing python 3.6 tests to fail.

