### PR TITLE
Fix import error

### DIFF
--- a/benchmark/testsystems/coupled_power_oscillators.py
+++ b/benchmark/testsystems/coupled_power_oscillators.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 
 from simtk import openmm


### PR DESCRIPTION
`os.environ` is referenced before `os` is imported