### PR TITLE
Fix box vectors

### DIFF
--- a/benchmark/experiments/driver.py
+++ b/benchmark/experiments/driver.py
@@ -48,7 +48,8 @@ class Experiment():
             exp.n_protocol_samples, exp.protocol_length, exp.marginal,
             store_potential_energy_traces=(exp.marginal=="full" and self.store_potential_energy_traces))
 
-        DeltaF_neq, squared_uncertainty = estimate_nonequilibrium_free_energy(self.result[0], self.result[1])
+        W_shads_F, W_shads_R = self.result["W_shads_F"], self.result["W_shads_R"]
+        DeltaF_neq, squared_uncertainty = estimate_nonequilibrium_free_energy(W_shads_F, W_shads_R)
         print(self)
         print("\t{:.3f} +/- {:.3f}".format(DeltaF_neq, np.sqrt(squared_uncertainty)))
 

--- a/benchmark/experiments/submission_scripts/collect_equilibrium_samples.py
+++ b/benchmark/experiments/submission_scripts/collect_equilibrium_samples.py
@@ -1,15 +1,18 @@
 import sys
 
-from benchmark.testsystems import dhfr_constrained, dhfr_unconstrained,\
-    waterbox_constrained, flexible_waterbox, t4_constrained, t4_unconstrained,\
+from benchmark.testsystems import dhfr_constrained, dhfr_unconstrained, \
+    waterbox_constrained, flexible_waterbox, t4_constrained, t4_unconstrained, \
     alanine_constrained, alanine_unconstrained, src_constrained
+from benchmark.testsystems.alanine_dipeptide import solvated_alanine_constrained, solvated_alanine_unconstrained
+from benchmark.testsystems.testsystems import dhfr_reaction_field
 
-systems = [None, dhfr_constrained, dhfr_unconstrained, src_constrained,\
-    waterbox_constrained, flexible_waterbox, t4_constrained, t4_unconstrained,\
-    alanine_constrained, alanine_unconstrained]
+systems = [dhfr_constrained, dhfr_unconstrained, src_constrained, \
+           waterbox_constrained, flexible_waterbox, t4_constrained, t4_unconstrained, \
+           alanine_constrained, alanine_unconstrained, solvated_alanine_constrained, solvated_alanine_unconstrained,
+           dhfr_reaction_field]
 
 for i in range(len(systems)):
     print(i, systems[i])
 
 if __name__ == "__main__":
-    systems[int(sys.argv[1])].sample_x_from_equilibrium()
+    systems[int(sys.argv[1]) - 1].sample_x_from_equilibrium()

--- a/benchmark/tests/test_bookkeeper.py
+++ b/benchmark/tests/test_bookkeeper.py
@@ -20,7 +20,7 @@ alanine_constrained = EquilibriumSimulator(platform=configure_platform("Referenc
                                            timestep=1.0 * unit.femtosecond,
                                            burn_in_length=500, n_samples=n_samples,
                                            thinning_interval=thinning_interval, name="alanine_constrained_test")
-print("Sample from cache: (xyz, periodic_box_vectors)\n", alanine_constrained.sample_x_from_equilibrium())
+print("Sample from cache: \n", alanine_constrained.sample_x_from_equilibrium())
 
 sim = NonequilibriumSimulator(alanine_constrained,
                               LangevinSplittingIntegrator("O V R V O", timestep=4.5 * unit.femtoseconds))

--- a/benchmark/tests/test_bookkeeper.py
+++ b/benchmark/tests/test_bookkeeper.py
@@ -1,0 +1,32 @@
+from simtk import unit
+
+from benchmark import simulation_parameters
+from benchmark.integrators import LangevinSplittingIntegrator
+from benchmark.testsystems.alanine_dipeptide import load_alanine
+from benchmark.testsystems.bookkeepers import NonequilibriumSimulator
+from benchmark.testsystems.configuration import configure_platform
+import numpy as np
+
+n_samples = 100
+thinning_interval = 100
+
+temperature = simulation_parameters["temperature"]
+from benchmark.testsystems.bookkeepers import EquilibriumSimulator
+
+top, sys, pos = load_alanine(constrained=True)
+alanine_constrained = EquilibriumSimulator(platform=configure_platform("Reference"),
+                                           topology=top, system=sys, positions=pos,
+                                           temperature=temperature,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           burn_in_length=500, n_samples=n_samples,
+                                           thinning_interval=thinning_interval, name="alanine_constrained_test")
+print("Sample from cache: (xyz, periodic_box_vectors)\n", alanine_constrained.sample_x_from_equilibrium())
+
+sim = NonequilibriumSimulator(alanine_constrained,
+                              LangevinSplittingIntegrator("O V R V O", timestep=4.5 * unit.femtoseconds))
+result = sim.collect_protocol_samples(100, 100, store_potential_energy_traces=True, store_W_shad_traces=True)
+print("<W>_(0 -> M): {:.3f}, <W>_(M -> 2M): {:.3f}".format(result["W_shads_F"].mean(), result["W_shads_R"].mean()))
+
+forward_traces = np.array([t[0] for t in result["W_shad_traces"]])
+print("0 -> M traces: mean W_shad per step: ", forward_traces.mean(0))
+print("0 -> M traces: mean cumulative W_shad per step: ", np.cumsum(forward_traces,1).mean(0))

--- a/benchmark/tests/test_bookkeeper.py
+++ b/benchmark/tests/test_bookkeeper.py
@@ -17,7 +17,7 @@ top, sys, pos = load_alanine(constrained=True)
 alanine_constrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=500, n_samples=n_samples,
                                            thinning_interval=thinning_interval, name="alanine_constrained_test")
 print("Sample from cache: (xyz, periodic_box_vectors)\n", alanine_constrained.sample_x_from_equilibrium())

--- a/benchmark/testsystems/alanine_dipeptide.py
+++ b/benchmark/testsystems/alanine_dipeptide.py
@@ -41,7 +41,7 @@ top, sys, pos = load_alanine(constrained=True)
 alanine_constrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=50000, n_samples=n_samples,
                                            thinning_interval=10000, name="alanine_constrained")
 
@@ -49,7 +49,7 @@ top, sys, pos = load_alanine(constrained=False)
 alanine_unconstrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=50000, n_samples=n_samples,
                                            thinning_interval=10000, name="alanine_unconstrained")
 
@@ -57,7 +57,7 @@ top, sys, pos = load_solvated_alanine(constrained=False)
 solvated_alanine_unconstrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                           topology=top, system=sys, positions=pos,
                                           temperature=temperature,
-                                          xcghmc_timestep=0.25 * unit.femtosecond,
+                                          timestep=0.25 * unit.femtosecond,
                                           burn_in_length=50000, n_samples=n_samples,
                                           thinning_interval=10000, name="solvated_alanine_unconstrained")
 
@@ -65,6 +65,6 @@ top, sys, pos = load_solvated_alanine(constrained=True)
 solvated_alanine_constrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                           topology=top, system=sys, positions=pos,
                                           temperature=temperature,
-                                          xcghmc_timestep=0.25 * unit.femtosecond,
+                                          timestep=0.25 * unit.femtosecond,
                                           burn_in_length=50000, n_samples=n_samples,
                                           thinning_interval=10000, name="solvated_alanine_constrained")

--- a/benchmark/testsystems/alanine_dipeptide.py
+++ b/benchmark/testsystems/alanine_dipeptide.py
@@ -41,7 +41,7 @@ top, sys, pos = load_alanine(constrained=True)
 alanine_constrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1.0 * unit.femtosecond,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
                                            burn_in_length=50000, n_samples=n_samples,
                                            thinning_interval=10000, name="alanine_constrained")
 
@@ -49,7 +49,7 @@ top, sys, pos = load_alanine(constrained=False)
 alanine_unconstrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1.0 * unit.femtosecond,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
                                            burn_in_length=50000, n_samples=n_samples,
                                            thinning_interval=10000, name="alanine_unconstrained")
 
@@ -57,14 +57,14 @@ top, sys, pos = load_solvated_alanine(constrained=False)
 solvated_alanine_unconstrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                           topology=top, system=sys, positions=pos,
                                           temperature=temperature,
-                                          ghmc_timestep=0.25 * unit.femtosecond,
-                                          burn_in_length=200000, n_samples=n_samples,
-                                          thinning_interval=200000, name="solvated_alanine_unconstrained")
+                                          xcghmc_timestep=0.25 * unit.femtosecond,
+                                          burn_in_length=50000, n_samples=n_samples,
+                                          thinning_interval=10000, name="solvated_alanine_unconstrained")
 
 top, sys, pos = load_solvated_alanine(constrained=True)
 solvated_alanine_constrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                           topology=top, system=sys, positions=pos,
                                           temperature=temperature,
-                                          ghmc_timestep=0.25 * unit.femtosecond,
-                                          burn_in_length=200000, n_samples=n_samples,
-                                          thinning_interval=200000, name="solvated_alanine_constrained")
+                                          xcghmc_timestep=0.25 * unit.femtosecond,
+                                          burn_in_length=50000, n_samples=n_samples,
+                                          thinning_interval=10000, name="solvated_alanine_constrained")

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -96,8 +96,8 @@ class EquilibriumSimulator():
         print("Minimizing...")
         self.unbiased_simulation.minimizeEnergy()
 
-        print('"Burning in" unbiased sampler for {:.3}ps...'.format(
-            (self.burn_in_length * self.timestep * 10).value_in_unit(unit.picoseconds)))
+        print('"Burning in" unbiased sampler for approximately {:.3}ps...'.format(
+            (self.burn_in_length * self.timestep * self.steps_per_hmc).value_in_unit(unit.picoseconds)))
         for _ in tqdm(range(self.burn_in_length)):
             self.unbiased_simulation.step(1)
         print("Burn-in XC-GHMC acceptance rate: {:.3f}%".format(100 * self.get_acceptance_rate()))

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -222,8 +222,8 @@ class NonequilibriumSimulator(BookkeepingSimulator):
             if store_potential_energy:
                 potential_energies = [get_potential()]
             if store_W_shad_trace:
-                total_energies = [get_energy()]
-                heats = [get_heat()]
+                total_energies = [E_0]
+                heats = [Q_0]
                 W_shad_trace = []
             for _ in range(n_steps):
                 self.simulation.step(1)

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -91,7 +91,7 @@ class EquilibriumSimulator():
         print("Collecting equilibrium samples for '%s'..." % self.name)
 
         self.unbiased_simulation = self.construct_unbiased_simulation()
-        set_positions(self.unbiased_simulation, pos)
+        set_positions(self.unbiased_simulation, self.positions)
         print("Minimizing...")
         self.unbiased_simulation.minimizeEnergy()
 

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -45,7 +45,7 @@ class BookkeepingSimulator():
 class EquilibriumSimulator():
     """Simulates a system at equilibrium."""
 
-    def __init__(self, platform, topology, system, positions, temperature, xcghmc_timestep,
+    def __init__(self, platform, topology, system, positions, temperature, timestep,
                  burn_in_length, n_samples, thinning_interval, name):
 
         self.platform = platform
@@ -53,7 +53,7 @@ class EquilibriumSimulator():
         self.system = system
         self.positions = positions
         self.temperature = temperature
-        self.xcghmc_timestep = xcghmc_timestep
+        self.timestep = timestep
         self.burn_in_length = burn_in_length
         self.n_samples = n_samples
         self.thinning_interval = thinning_interval
@@ -83,7 +83,7 @@ class EquilibriumSimulator():
         n_steps = 10
         return self.construct_simulation(
             XCGHMCIntegrator(temperature=self.temperature, steps_per_hmc=n_steps, extra_chances=15,
-                             steps_per_extra_hmc=n_steps, timestep=self.xcghmc_timestep), use_reference=use_reference)
+                             steps_per_extra_hmc=n_steps, timestep=self.timestep), use_reference=use_reference)
 
     def collect_equilibrium_samples(self):
         """Collect equilibrium samples, return as (n_samples, n_atoms, 3) numpy array"""
@@ -96,7 +96,7 @@ class EquilibriumSimulator():
         self.unbiased_simulation.minimizeEnergy()
 
         print('"Burning in" unbiased sampler for {:.3}ps...'.format(
-            (self.burn_in_length * self.xcghmc_timestep * 10).value_in_unit(unit.picoseconds)))
+            (self.burn_in_length * self.timestep * 10).value_in_unit(unit.picoseconds)))
         for _ in tqdm(range(self.burn_in_length)):
             self.unbiased_simulation.step(1)
         print("Burn-in XC-GHMC acceptance rate: {:.3f}%".format(100 * self.get_acceptance_rate()))

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -81,7 +81,7 @@ class EquilibriumSimulator():
 
     def construct_unbiased_simulation(self, use_reference=False):
         n_steps = 10
-        self.construct_simulation(
+        return self.construct_simulation(
             XCGHMCIntegrator(temperature=self.temperature, steps_per_hmc=n_steps, extra_chances=15,
                              steps_per_extra_hmc=n_steps, timestep=self.xcghmc_timestep), use_reference=use_reference)
 
@@ -96,7 +96,7 @@ class EquilibriumSimulator():
         self.unbiased_simulation.minimizeEnergy()
 
         print('"Burning in" unbiased sampler for {:.3}ps...'.format(
-            (self.burn_in_length * self.xcghmc_timestep * n_steps).value_in_unit(unit.picoseconds)))
+            (self.burn_in_length * self.xcghmc_timestep * 10).value_in_unit(unit.picoseconds)))
         for _ in tqdm(range(self.burn_in_length)):
             self.unbiased_simulation.step(1)
         print("Burn-in XC-GHMC acceptance rate: {:.3f}%".format(100 * self.get_acceptance_rate()))

--- a/benchmark/testsystems/coupled_power_oscillators.py
+++ b/benchmark/testsystems/coupled_power_oscillators.py
@@ -142,6 +142,6 @@ top, sys, pos = testsystem.topology, testsystem.system, testsystem.positions
 coupled_power_oscillators = EquilibriumSimulator(platform=configure_platform("CPU"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=1000, n_samples=n_samples,
                                            thinning_interval=10, name="coupled_power_oscillators")

--- a/benchmark/testsystems/coupled_power_oscillators.py
+++ b/benchmark/testsystems/coupled_power_oscillators.py
@@ -142,6 +142,6 @@ top, sys, pos = testsystem.topology, testsystem.system, testsystem.positions
 coupled_power_oscillators = EquilibriumSimulator(platform=configure_platform("CPU"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1.0 * unit.femtosecond,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
                                            burn_in_length=1000, n_samples=n_samples,
                                            thinning_interval=10, name="coupled_power_oscillators")

--- a/benchmark/testsystems/testsystems.py
+++ b/benchmark/testsystems/testsystems.py
@@ -74,11 +74,10 @@ def load_dhfr_reaction_field(constrained=True):
 
     return topology, system, positions
 
-temperature = simulation_parameters["temperature"]
 n_samples = 1000
-default_thinning = 10000
-burn_in_length = 1000000
-default_timestep = 0.5 * unit.femtosecond
+default_thinning = 1000
+burn_in_length = 10000
+default_timestep = 0.25 * unit.femtosecond
 from benchmark.testsystems.bookkeepers import EquilibriumSimulator
 
 def construct_simulator(name, top, sys, pos, timestep=default_timestep,
@@ -86,21 +85,21 @@ def construct_simulator(name, top, sys, pos, timestep=default_timestep,
     return EquilibriumSimulator(platform=configure_platform("CUDA"),
                          topology=top, system=sys, positions=pos,
                          temperature=temperature,
-                         ghmc_timestep=timestep,
+                         xcghmc_timestep=timestep,
                          burn_in_length=burn_in_length, n_samples=n_samples,
                          thinning_interval=thinning_interval, name=name)
 
 # DHFR
 dhfr_constrained = construct_simulator("dhfr_constrained", *load_dhfr_explicit(constrained=True))
 top, sys, pos = load_dhfr_explicit(constrained=False)
-dhfr_unconstrained = construct_simulator("dhfr_unconstrained", top, sys, pos, default_timestep / 10, default_thinning * 5)
+dhfr_unconstrained = construct_simulator("dhfr_unconstrained", top, sys, pos, default_timestep / 2.5, default_thinning * 2.5)
 
 # DHFR reaction field (for the MTS experiment)
 dhfr_reaction_field = construct_simulator("dhfr_constrained_reaction_field", *load_dhfr_reaction_field(constrained=True))
 
 # Src explicit
 top, sys, pos = load_src_explicit(constrained=True)
-src_constrained = construct_simulator("src_constrained", top, sys, pos, default_timestep, int(default_thinning / 10))
+src_constrained = construct_simulator("src_constrained", top, sys, pos, default_timestep / 2.5, default_thinning * 2.5)
 
 # T4 lysozyme
 t4_constrained = construct_simulator("t4_constrained", *load_t4_implicit(constrained=True))
@@ -111,6 +110,6 @@ top, sys, pos = load_constraint_coupled_harmonic_oscillators(constrained=True)
 constraint_coupled_harmonic_oscillators = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1000.0 * unit.femtosecond,
+                                           xcghmc_timestep=1000.0 * unit.femtosecond,
                                            burn_in_length=50, n_samples=10000,
                                            thinning_interval=10, name="constraint_coupled_harmonic_oscillators")

--- a/benchmark/testsystems/testsystems.py
+++ b/benchmark/testsystems/testsystems.py
@@ -85,7 +85,7 @@ def construct_simulator(name, top, sys, pos, timestep=default_timestep,
     return EquilibriumSimulator(platform=configure_platform("CUDA"),
                          topology=top, system=sys, positions=pos,
                          temperature=temperature,
-                         xcghmc_timestep=timestep,
+                         timestep=timestep,
                          burn_in_length=burn_in_length, n_samples=n_samples,
                          thinning_interval=thinning_interval, name=name)
 
@@ -110,6 +110,6 @@ top, sys, pos = load_constraint_coupled_harmonic_oscillators(constrained=True)
 constraint_coupled_harmonic_oscillators = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1000.0 * unit.femtosecond,
+                                           timestep=1000.0 * unit.femtosecond,
                                            burn_in_length=50, n_samples=10000,
                                            thinning_interval=10, name="constraint_coupled_harmonic_oscillators")

--- a/benchmark/testsystems/testsystems.py
+++ b/benchmark/testsystems/testsystems.py
@@ -69,7 +69,7 @@ def load_dhfr_reaction_field(constrained=True):
     topology, system, positions = testsystem.topology, testsystem.system, testsystem.positions
 
     keep_only_some_forces(system)
-    system = replace_reaction_field(system)
+    system = replace_reaction_field(system, shifted=True)
     add_barostat(system)
 
     return topology, system, positions

--- a/benchmark/testsystems/waterbox.py
+++ b/benchmark/testsystems/waterbox.py
@@ -19,7 +19,7 @@ top, sys, pos = load_waterbox(constrained=True)
 waterbox_constrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=100000, n_samples=1000,
                                            thinning_interval=10000, name="waterbox_constrained")
 
@@ -27,6 +27,6 @@ top, sys, pos = load_waterbox(constrained=False)
 flexible_waterbox = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=0.5 * unit.femtosecond,
+                                           timestep=0.5 * unit.femtosecond,
                                            burn_in_length=200000, n_samples=1000,
                                            thinning_interval=20000, name="flexible_waterbox")

--- a/benchmark/testsystems/waterbox.py
+++ b/benchmark/testsystems/waterbox.py
@@ -19,7 +19,7 @@ top, sys, pos = load_waterbox(constrained=True)
 waterbox_constrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1.0 * unit.femtosecond,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
                                            burn_in_length=100000, n_samples=1000,
                                            thinning_interval=10000, name="waterbox_constrained")
 
@@ -27,6 +27,6 @@ top, sys, pos = load_waterbox(constrained=False)
 flexible_waterbox = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=0.5 * unit.femtosecond,
+                                           xcghmc_timestep=0.5 * unit.femtosecond,
                                            burn_in_length=200000, n_samples=1000,
                                            thinning_interval=20000, name="flexible_waterbox")

--- a/benchmark/utilities/openmm_utilities.py
+++ b/benchmark/utilities/openmm_utilities.py
@@ -31,8 +31,8 @@ def get_velocities(simulation):
 def set_positions(simulation, x, box_vectors=None):
     """Set particle positions, and optionally box_vectors"""
     simulation.context.setPositions(x)
-    if box_vectors != None:
-        simulation.context.setPeriodicBoxVectors(box_vectors)
+    if type(box_vectors) != type(None):
+        simulation.context.setPeriodicBoxVectors(*box_vectors)
 
 
 def set_velocities(simulation, v):

--- a/benchmark/utilities/openmm_utilities.py
+++ b/benchmark/utilities/openmm_utilities.py
@@ -28,9 +28,11 @@ def get_velocities(simulation):
     return simulation.context.getState(getVelocities=True).getVelocities(asNumpy=True)
 
 
-def set_positions(simulation, x):
-    """Set particle positions"""
+def set_positions(simulation, x, box_vectors=None):
+    """Set particle positions, and optionally box_vectors"""
     simulation.context.setPositions(x)
+    if box_vectors != None:
+        simulation.context.setPeriodicBoxVectors(box_vectors)
 
 
 def set_velocities(simulation, v):


### PR DESCRIPTION
Main change: Instead of storing only xyz positions for each equilibrium sample, also store periodic box vectors.
Rationale: @jchodera suspected that failing to set the box vectors properly at the start of each protocol was causing an anomaly in some of the measurements, and I agree that's likely to be the culprit!

Other changes:
* Use XCHMC instead of GHMC to generate equilibrium samples: Makes a dramatic difference in correlation times. I also removed some extraneous complexity from the equilibrium sampling code.
* Add option to store full shadow-work traces from protocols, rather than just the total accumulated shadow-work: may be helpful for illustration and debugging.