### PR TITLE
[WIP] Estimator comparison

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ os:
 
 env:
   matrix:
-    - python=2.7  CONDA_PY=2.7
     - python=3.5  CONDA_PY=3.5
     - python=3.6  CONDA_PY=3.6
 

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -93,10 +93,7 @@ def estimate_kl_div(testsystem_name, scheme, dt, marginal, collision_rate,
 
     # near-equilibrium estimate
     W_F_hat = np.mean([s["W_shad_forward"] for s in outer_samples])
-
-    # TODO: I've collected many W_R samples per W_F sample: Decide whether to perform an average over these.
     W_R_hat = np.mean([s["Ws"][0] for s in outer_samples])  # picking the first W_R sample associated with each W_F
-    # W_R_hat = np.mean([np.mean(s["Ws"][:,-1]) for s in outer_samples]) # taking a mean over all W_R samples associated with each W_F
     near_eq_estimate = 0.5 * (W_F_hat - W_R_hat)
 
 

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -29,6 +29,14 @@ n_inner_samples = 100
 n_outer_samples = 100
 n_steps = 1000
 
+
+def stdev_log_rho_pi(w):
+    """Estimate the standard deviation of the estimate of log < e^{-w} >_{x; \Lambda}
+
+    Note : This will be an underestimate esp. when len(w) is small or stdev_log_rho_pi is large.
+    """
+    return np.std(np.exp(-w)) / (np.mean(np.exp(-w)) * np.sqrt(len(w)))
+
 def estimate_from_work_samples(work_samples):
     """Returns an estimate of log(rho(x) / pi(x)) from unitless work_samples initialized at x"""
     return np.log(np.mean(np.exp(-np.array(work_samples))))

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -12,8 +12,8 @@ from benchmark.testsystems.bookkeepers import get_state_as_mdtraj
 
 # experiment variables
 testsystems = {
-    "alanine_constrained": alanine_constrained,
-    # "waterbox_constrained": waterbox_constrained,
+    # "alanine_constrained": alanine_constrained,
+    "waterbox_constrained": waterbox_constrained,
     # "t4_constrained": t4_constrained
 }
 splittings = {"OVRVO": "O V R V O",

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -36,9 +36,6 @@ inner_loop_batch_size = 1
 inner_loop_stdev_threshold = 0.1
 inner_loop_max_samples = 1000
 
-# naive outer-loop params
-n_outer_samples = 100
-
 # adaptive outer-loop params
 outer_loop_initial_size = 50
 outer_loop_batch_size = 1

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -46,7 +46,17 @@ outer_loop_max_samples = 1000
 def stdev_log_rho_pi(w):
     """Approximate the standard deviation of the estimate of log < e^{-w} >_{x; \Lambda}
 
-    Note : This will be an underestimate esp. when len(w) is small or stdev_log_rho_pi is large.
+    Parameters
+    ----------
+    w : unitless (kT) numpy array of work samples
+    
+    Returns
+    -------
+    stdev : float
+
+    Notes
+    -----
+    This will be an underestimate esp. when len(w) is small or stdev_log_rho_pi is large.
     """
 
     # use leading term in taylor expansion: anecdotally, looks like it's in good agreement with

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -1,0 +1,153 @@
+from openmmtools.constants import kB
+import numpy as np
+from benchmark.testsystems import alanine_constrained
+from benchmark.integrators import LangevinSplittingIntegrator
+from benchmark.testsystems import NonequilibriumSimulator
+from benchmark.testsystems.bookkeepers import get_state_as_mdtraj
+from benchmark import simulation_parameters
+from simtk import unit
+from tqdm import tqdm
+
+
+testsystem = alanine_constrained
+
+temperature = simulation_parameters['temperature']
+
+kT = kB * temperature
+conversion_factor = unit.kilojoule_per_mole / kT
+
+splittings = {"OVRVO": "O V R V O",
+              "ORVRO": "O R V R O",
+              "RVOVR": "R V O V R",
+              "VRORV": "V R O R V",
+              }
+
+
+dt_range = np.array([0.1] + list(np.arange(0.5, 4.001, 0.5)))
+marginals = ["configuration", "full"]
+
+collision_rates = {"low": 1.0 / unit.picoseconds,
+                   "high": 91.0 / unit.picoseconds}
+
+def convert_to_kT(x_in_kJ_mol):
+    return x_in_kJ_mol * conversion_factor
+
+
+n_inner_samples = 100
+n_outer_samples = 1000
+n_steps = 1000
+
+
+
+def estimate_from_work_traces(work_traces):
+    """Returns an estimate of log(rho(x) / pi(x)) from work_traces initialized at x"""
+    return np.log(np.mean(np.exp(-np.array(work_traces)), 0))
+
+
+def inner_sample(noneq_sim, x, v, n_steps, marginal="full"):
+
+    if marginal == "full":
+        pass
+    elif marginal == "configuration":
+        v = noneq_sim.sample_v_given_x(x)
+
+    return convert_to_kT(noneq_sim.accumulate_shadow_work(x, v, n_steps, store_W_shad_trace=True)['W_shad_trace'])
+
+
+def outer_sample(index=0, noneq_sim=None, marginal="full", n_inner_samples=100, n_steps=1000):
+    # (x0, v0) drawn from pi
+    x0 = noneq_sim.sample_x_from_equilibrium()
+    v0 = noneq_sim.sample_v_given_x(x0)
+
+    # (x, v) drawn from rho
+    W_shad_forward = convert_to_kT(noneq_sim.accumulate_shadow_work(x0, v0, n_steps)["W_shad"])
+    x = get_state_as_mdtraj(noneq_sim.simulation)
+    v = noneq_sim.simulation.context.getState(getVelocities=True).getVelocities(asNumpy=True)
+
+    Ws = []
+    for _ in range(n_inner_samples):
+        Ws.append(inner_sample(noneq_sim, x, v, n_steps, marginal))
+
+    return {
+        "xv": (x, v),
+        "Ws": np.array(Ws),
+        "estimate": estimate_from_work_traces(Ws),
+        "W_shad_forward": W_shad_forward
+    }
+
+
+from multiprocessing import Pool
+from functools import partial
+
+
+def estimate_kl_div(scheme, dt, marginal, collision_rate,
+                    n_inner_samples=100, n_outer_samples=100, n_steps=1000, parallel=False):
+
+    integrator = LangevinSplittingIntegrator(splittings[scheme],
+                                             temperature=temperature,
+                                             collision_rate=collision_rates[collision_rate],
+                                             timestep=dt * unit.femtosecond)
+    noneq_sim = NonequilibriumSimulator(testsystem, integrator)
+
+    if parallel:
+        pool = Pool(8)
+
+        collect_a_sample = partial(outer_sample, noneq_sim=noneq_sim, marginal=marginal,
+                                   n_inner_samples=n_inner_samples, n_steps=n_steps)
+
+        outer_samples = pool.map(collect_a_sample, range(n_outer_samples))
+
+        del (pool)
+
+    else:
+        outer_samples = []
+        for _ in tqdm(range(n_outer_samples)):
+            outer_samples.append(outer_sample(noneq_sim=noneq_sim, marginal=marginal, n_inner_samples=n_inner_samples, n_steps=n_steps))
+
+    # estimate D_KL as a sample average over x ~ rho of log(rho(x) / pi(x))
+    new_estimate = np.mean([s["estimate"] for s in outer_samples], 0)
+
+    # near-equilibrium estimate
+    W_F_hat = np.mean([s["W_shad_forward"] for s in outer_samples])
+
+    # TODO: I've collected many W_R samples per W_F sample: Decide whether to perform an average over these.
+    W_R_hat = np.mean([s["Ws"][0, -1] for s in outer_samples])  # picking the first W_R sample associated with each W_F
+    # W_R_hat = np.mean([np.mean(s["Ws"][:,-1]) for s in outer_samples]) # taking a mean over all W_R samples associated with each W_F
+    near_eq_estimate = 0.5 * (W_F_hat - W_R_hat)
+
+    return {
+        "samples": outer_samples,
+        "new_estimate": new_estimate,
+        "near_eq_estimate": near_eq_estimate,
+    }
+
+
+
+def save(job_id, experiment, result):
+    from pickle import dump
+
+    with open( "{}.pkl".format(job_id), 'w') as f:
+        dump((experiment, result), f)
+
+if __name__ == '__main__':
+    experiments = []
+    for scheme in splittings:
+        for dt in dt_range:
+            for marginal in marginals:
+                for collision_rate in collision_rates:
+                    experiments.append((scheme, dt, marginal, collision_rate))
+
+    print(len(experiments))
+
+    import sys
+
+    try:
+        job_id = int(sys.argv[1])
+    except:
+        print("No job_id supplied! Doing job_id 1")
+        job_id = 1
+
+    experiment = experiments[job_id - 1]
+    (scheme, dt, marginal, collision_rate) = experiment
+    result = estimate_kl_div(scheme, dt, marginal, collision_rate, n_inner_samples, n_outer_samples, n_steps)
+    save(job_id, experiment, result)

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -307,7 +307,7 @@ def resample_Ws(Ws):
 
     for i in range(n_outer_samples):
         n_cols = len(Ws_[i])
-        Ws_[i] = Ws_[i, np.random.randint(0, n_cols, n_cols)]  # within each row, resample the columns independently
+        Ws_[i] = Ws_[i][np.random.randint(0, n_cols, n_cols)]  # within each row, resample the columns independently
     return Ws_
 
 def save(job_id, experiment, result):

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -29,10 +29,6 @@ marginals = ["configuration", "full"]
 collision_rates = {"low": 1.0 / unit.picoseconds,
                    "high": 91.0 / unit.picoseconds}
 
-def convert_to_kT(x_in_kJ_mol):
-    return x_in_kJ_mol * conversion_factor
-
-
 n_inner_samples = 100
 n_outer_samples = 1000
 n_steps = 1000
@@ -51,7 +47,7 @@ def inner_sample(noneq_sim, x, v, n_steps, marginal="full"):
     elif marginal == "configuration":
         v = noneq_sim.sample_v_given_x(x)
 
-    return convert_to_kT(noneq_sim.accumulate_shadow_work(x, v, n_steps, store_W_shad_trace=True)['W_shad_trace'])
+    return noneq_sim.accumulate_shadow_work(x, v, n_steps, store_W_shad_trace=True)['W_shad_trace']
 
 
 def outer_sample(index=0, noneq_sim=None, marginal="full", n_inner_samples=100, n_steps=1000):
@@ -60,7 +56,7 @@ def outer_sample(index=0, noneq_sim=None, marginal="full", n_inner_samples=100, 
     v0 = noneq_sim.sample_v_given_x(x0)
 
     # (x, v) drawn from rho
-    W_shad_forward = convert_to_kT(noneq_sim.accumulate_shadow_work(x0, v0, n_steps)["W_shad"])
+    W_shad_forward = noneq_sim.accumulate_shadow_work(x0, v0, n_steps)["W_shad"]
     x = get_state_as_mdtraj(noneq_sim.simulation)
     v = noneq_sim.simulation.context.getState(getVelocities=True).getVelocities(asNumpy=True)
 

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -281,6 +281,35 @@ def estimate_kl_div_adaptive_outer_loop(
     return result
 
 
+def resample_Ws(Ws):
+    """Generate a bootstrap sample of the Ws structure.
+
+    Parameters
+    ----------
+    Ws : iterable of iterables
+        Each element of Ws is an iterable of floats, potentially of varying length
+        * len(Ws) is the number of outer-loop samples
+        * [len(w) for w in Ws] are the numbers of inner-loop samples
+            associated with each outer-loop sample
+
+    Algorithm
+    ---------
+    * Resample elements of Ws uniformly with replacement, assign to Ws_
+    * For each element in Ws_, resample its elements uniformly with replacement
+
+    Returns
+    -------
+    Ws_ : iterable of iterables, same shapes as input Ws
+    """
+    n_outer_samples = len(Ws)
+
+    Ws_ = Ws[np.random.randint(0, n_outer_samples, n_outer_samples)]  # resample the rows
+
+    for i in range(n_outer_samples):
+        n_cols = len(Ws_[i])
+        Ws_[i] = Ws_[i, np.random.randint(0, n_cols, n_cols)]  # within each row, resample the columns independently
+    return Ws_
+
 def save(job_id, experiment, result):
     from pickle import dump
 

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -33,7 +33,7 @@ n_steps = 1000  # number of steps until system is judged to have reached "steady
 inner_loop_initial_size = 50
 inner_loop_batch_size = 1
 inner_loop_stdev_threshold = 0.1
-inner_loop_max_samples = 1000
+inner_loop_max_samples = 10000
 
 # adaptive outer-loop params
 outer_loop_initial_size = 50

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -30,9 +30,6 @@ collision_rate = 1.0 / unit.picoseconds
 temperature = simulation_parameters['temperature']
 n_steps = 1000  # number of steps until system is judged to have reached "steady-state"
 
-# naive inner-loop params
-n_inner_samples = 100
-
 # adaptive inner-loop params
 inner_loop_initial_size = 50
 inner_loop_batch_size = 1

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -351,5 +351,4 @@ if __name__ == '__main__':
                                                  batch_size=outer_loop_batch_size,
                                                  max_samples=outer_loop_max_samples,
                                                  threshold=outer_loop_stdev_threshold)
-    # result = estimate_kl_div_naive_outer_loop(noneq_sim, marginal, outer_sample_fxn, n_outer_samples=n_outer_samples, n_steps=n_steps)
     save(job_id, experiment, result)

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -8,7 +8,6 @@ from simtk import unit
 from tqdm import tqdm
 
 testsystems = {
-    "alanine_constrained": alanine_constrained,
     "waterbox_constrained": waterbox_constrained,
     "t4_constrained": t4_constrained
 }
@@ -26,8 +25,8 @@ marginals = ["configuration", "full"]
 
 collision_rate = 1.0 / unit.picoseconds
 
-n_inner_samples = 10
-n_outer_samples = 200
+n_inner_samples = 100
+n_outer_samples = 100
 n_steps = 1000
 
 def estimate_from_work_samples(work_samples):
@@ -134,26 +133,4 @@ if __name__ == '__main__':
         save(job_id, experiment, result)
 
     except:
-        print("No job_id supplied! Doing a quick comparison of configuration and full...")
-
-        experiment1 = ("VRORV", 4.0, "configuration", "alanine_constrained")
-        experiment2 = ("VRORV", 4.0, "full", "alanine_constrained")
-
-        (scheme, dt, marginal, testsystem) = experiment1
-        result1 = estimate_kl_div(testsystem, scheme, dt, marginal, collision_rate, n_inner_samples, n_outer_samples,
-                                 n_steps)
-        save("conf", experiment1, result1)
-
-        (scheme, dt, marginal, testsystem) = experiment2
-        result2 = estimate_kl_div(testsystem, scheme, dt, marginal, collision_rate, n_inner_samples, n_outer_samples,
-                                  n_steps)
-        save("full", experiment2, result2)
-
-
-        print('conf')
-        print('\tnew_estimate: {:.3f}'.format(result1["new_estimate"]))
-        print('\tnear_eq_estimate: {:.3f}'.format(result1["near_eq_estimate"]))
-
-        print('full')
-        print('\tnew_estimate: {:.3f}'.format(result2["new_estimate"]))
-        print('\tnear_eq_estimate: {:.3f}'.format(result2["near_eq_estimate"]))
+        print("No job_id supplied!")

--- a/benchmark/evaluation/compare_near_eq_and_exact.py
+++ b/benchmark/evaluation/compare_near_eq_and_exact.py
@@ -49,7 +49,7 @@ def stdev_log_rho_pi(w):
     Parameters
     ----------
     w : unitless (kT) numpy array of work samples
-    
+
     Returns
     -------
     stdev : float
@@ -58,6 +58,9 @@ def stdev_log_rho_pi(w):
     -----
     This will be an underestimate esp. when len(w) is small or stdev_log_rho_pi is large.
     """
+
+    assert(type(w) != unit.Quantity) # assert w is unitless
+    assert(type(w) == np.ndarray) # assert w is a numpy array
 
     # use leading term in taylor expansion: anecdotally, looks like it's in good agreement with
     # bootstrapped uncertainty estimates up to ~0.5-0.75, then becomes an increasingly bad underestimate

--- a/benchmark/evaluation/comparison.lsf
+++ b/benchmark/evaluation/comparison.lsf
@@ -1,0 +1,22 @@
+#!/bin/bash
+#BSUB -J validate
+#BSUB -n 1
+#BSUB -q gpuqueue -gpu -
+#BSUB -W 24:00
+#BSUB -o %J.stdout
+#BSUB -eo %J.stderr
+#BSUB -L /bin/bash
+
+cd $LS_SUBCWD
+PATH=$PATH:/home/fassj/anaconda3/bin
+source activate integrators
+sleep 10
+python compare_near_eq_and_exact.py $LSB_JOBINDEX
+outputfile=$LSB_JOBINDEX".pkl"
+if [ -f "$outputfile" ]
+then
+   echo "output not found -- something must have gone wrong! trying again once"
+   python compare_near_eq_and_exact.py $LSB_JOBINDEX
+else
+   echo "output found, terminating sucessfully"
+fi

--- a/benchmark/evaluation/reproduce.sh
+++ b/benchmark/evaluation/reproduce.sh
@@ -1,0 +1,1 @@
+bsub -J "comparison[1-72]%50" < comparison.lsf

--- a/benchmark/experiments/driver.py
+++ b/benchmark/experiments/driver.py
@@ -48,7 +48,8 @@ class Experiment():
             exp.n_protocol_samples, exp.protocol_length, exp.marginal,
             store_potential_energy_traces=(exp.marginal=="full" and self.store_potential_energy_traces))
 
-        DeltaF_neq, squared_uncertainty = estimate_nonequilibrium_free_energy(self.result[0], self.result[1])
+        W_shads_F, W_shads_R = self.result["W_shads_F"], self.result["W_shads_R"]
+        DeltaF_neq, squared_uncertainty = estimate_nonequilibrium_free_energy(W_shads_F, W_shads_R)
         print(self)
         print("\t{:.3f} +/- {:.3f}".format(DeltaF_neq, np.sqrt(squared_uncertainty)))
 

--- a/benchmark/experiments/submission_scripts/collect_equilibrium_samples.py
+++ b/benchmark/experiments/submission_scripts/collect_equilibrium_samples.py
@@ -1,15 +1,18 @@
 import sys
 
-from benchmark.testsystems import dhfr_constrained, dhfr_unconstrained,\
-    waterbox_constrained, flexible_waterbox, t4_constrained, t4_unconstrained,\
+from benchmark.testsystems import dhfr_constrained, dhfr_unconstrained, \
+    waterbox_constrained, flexible_waterbox, t4_constrained, t4_unconstrained, \
     alanine_constrained, alanine_unconstrained, src_constrained
+from benchmark.testsystems.alanine_dipeptide import solvated_alanine_constrained, solvated_alanine_unconstrained
+from benchmark.testsystems.testsystems import dhfr_reaction_field
 
-systems = [None, dhfr_constrained, dhfr_unconstrained, src_constrained,\
-    waterbox_constrained, flexible_waterbox, t4_constrained, t4_unconstrained,\
-    alanine_constrained, alanine_unconstrained]
+systems = [dhfr_constrained, dhfr_unconstrained, src_constrained, \
+           waterbox_constrained, flexible_waterbox, t4_constrained, t4_unconstrained, \
+           alanine_constrained, alanine_unconstrained, solvated_alanine_constrained, solvated_alanine_unconstrained,
+           dhfr_reaction_field]
 
 for i in range(len(systems)):
     print(i, systems[i])
 
 if __name__ == "__main__":
-    systems[int(sys.argv[1])].sample_x_from_equilibrium()
+    systems[int(sys.argv[1]) - 1].sample_x_from_equilibrium()

--- a/benchmark/tests/test_bookkeeper.py
+++ b/benchmark/tests/test_bookkeeper.py
@@ -20,7 +20,7 @@ alanine_constrained = EquilibriumSimulator(platform=configure_platform("Referenc
                                            timestep=1.0 * unit.femtosecond,
                                            burn_in_length=500, n_samples=n_samples,
                                            thinning_interval=thinning_interval, name="alanine_constrained_test")
-print("Sample from cache: (xyz, periodic_box_vectors)\n", alanine_constrained.sample_x_from_equilibrium())
+print("Sample from cache: \n", alanine_constrained.sample_x_from_equilibrium())
 
 sim = NonequilibriumSimulator(alanine_constrained,
                               LangevinSplittingIntegrator("O V R V O", timestep=4.5 * unit.femtoseconds))

--- a/benchmark/tests/test_bookkeeper.py
+++ b/benchmark/tests/test_bookkeeper.py
@@ -1,0 +1,32 @@
+from simtk import unit
+
+from benchmark import simulation_parameters
+from benchmark.integrators import LangevinSplittingIntegrator
+from benchmark.testsystems.alanine_dipeptide import load_alanine
+from benchmark.testsystems.bookkeepers import NonequilibriumSimulator
+from benchmark.testsystems.configuration import configure_platform
+import numpy as np
+
+n_samples = 100
+thinning_interval = 100
+
+temperature = simulation_parameters["temperature"]
+from benchmark.testsystems.bookkeepers import EquilibriumSimulator
+
+top, sys, pos = load_alanine(constrained=True)
+alanine_constrained = EquilibriumSimulator(platform=configure_platform("Reference"),
+                                           topology=top, system=sys, positions=pos,
+                                           temperature=temperature,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           burn_in_length=500, n_samples=n_samples,
+                                           thinning_interval=thinning_interval, name="alanine_constrained_test")
+print("Sample from cache: (xyz, periodic_box_vectors)\n", alanine_constrained.sample_x_from_equilibrium())
+
+sim = NonequilibriumSimulator(alanine_constrained,
+                              LangevinSplittingIntegrator("O V R V O", timestep=4.5 * unit.femtoseconds))
+result = sim.collect_protocol_samples(100, 100, store_potential_energy_traces=True, store_W_shad_traces=True)
+print("<W>_(0 -> M): {:.3f}, <W>_(M -> 2M): {:.3f}".format(result["W_shads_F"].mean(), result["W_shads_R"].mean()))
+
+forward_traces = np.array([t[0] for t in result["W_shad_traces"]])
+print("0 -> M traces: mean W_shad per step: ", forward_traces.mean(0))
+print("0 -> M traces: mean cumulative W_shad per step: ", np.cumsum(forward_traces,1).mean(0))

--- a/benchmark/tests/test_bookkeeper.py
+++ b/benchmark/tests/test_bookkeeper.py
@@ -17,7 +17,7 @@ top, sys, pos = load_alanine(constrained=True)
 alanine_constrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=500, n_samples=n_samples,
                                            thinning_interval=thinning_interval, name="alanine_constrained_test")
 print("Sample from cache: (xyz, periodic_box_vectors)\n", alanine_constrained.sample_x_from_equilibrium())

--- a/benchmark/testsystems/alanine_dipeptide.py
+++ b/benchmark/testsystems/alanine_dipeptide.py
@@ -41,7 +41,7 @@ top, sys, pos = load_alanine(constrained=True)
 alanine_constrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=50000, n_samples=n_samples,
                                            thinning_interval=10000, name="alanine_constrained")
 
@@ -49,7 +49,7 @@ top, sys, pos = load_alanine(constrained=False)
 alanine_unconstrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=50000, n_samples=n_samples,
                                            thinning_interval=10000, name="alanine_unconstrained")
 
@@ -57,7 +57,7 @@ top, sys, pos = load_solvated_alanine(constrained=False)
 solvated_alanine_unconstrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                           topology=top, system=sys, positions=pos,
                                           temperature=temperature,
-                                          xcghmc_timestep=0.25 * unit.femtosecond,
+                                          timestep=0.25 * unit.femtosecond,
                                           burn_in_length=50000, n_samples=n_samples,
                                           thinning_interval=10000, name="solvated_alanine_unconstrained")
 
@@ -65,6 +65,6 @@ top, sys, pos = load_solvated_alanine(constrained=True)
 solvated_alanine_constrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                           topology=top, system=sys, positions=pos,
                                           temperature=temperature,
-                                          xcghmc_timestep=0.25 * unit.femtosecond,
+                                          timestep=0.25 * unit.femtosecond,
                                           burn_in_length=50000, n_samples=n_samples,
                                           thinning_interval=10000, name="solvated_alanine_constrained")

--- a/benchmark/testsystems/alanine_dipeptide.py
+++ b/benchmark/testsystems/alanine_dipeptide.py
@@ -41,7 +41,7 @@ top, sys, pos = load_alanine(constrained=True)
 alanine_constrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1.0 * unit.femtosecond,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
                                            burn_in_length=50000, n_samples=n_samples,
                                            thinning_interval=10000, name="alanine_constrained")
 
@@ -49,7 +49,7 @@ top, sys, pos = load_alanine(constrained=False)
 alanine_unconstrained = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1.0 * unit.femtosecond,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
                                            burn_in_length=50000, n_samples=n_samples,
                                            thinning_interval=10000, name="alanine_unconstrained")
 
@@ -57,14 +57,14 @@ top, sys, pos = load_solvated_alanine(constrained=False)
 solvated_alanine_unconstrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                           topology=top, system=sys, positions=pos,
                                           temperature=temperature,
-                                          ghmc_timestep=0.25 * unit.femtosecond,
-                                          burn_in_length=200000, n_samples=n_samples,
-                                          thinning_interval=200000, name="solvated_alanine_unconstrained")
+                                          xcghmc_timestep=0.25 * unit.femtosecond,
+                                          burn_in_length=50000, n_samples=n_samples,
+                                          thinning_interval=10000, name="solvated_alanine_unconstrained")
 
 top, sys, pos = load_solvated_alanine(constrained=True)
 solvated_alanine_constrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                           topology=top, system=sys, positions=pos,
                                           temperature=temperature,
-                                          ghmc_timestep=0.25 * unit.femtosecond,
-                                          burn_in_length=200000, n_samples=n_samples,
-                                          thinning_interval=200000, name="solvated_alanine_constrained")
+                                          xcghmc_timestep=0.25 * unit.femtosecond,
+                                          burn_in_length=50000, n_samples=n_samples,
+                                          thinning_interval=10000, name="solvated_alanine_constrained")

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -96,8 +96,8 @@ class EquilibriumSimulator():
         print("Minimizing...")
         self.unbiased_simulation.minimizeEnergy()
 
-        print('"Burning in" unbiased sampler for {:.3}ps...'.format(
-            (self.burn_in_length * self.timestep * 10).value_in_unit(unit.picoseconds)))
+        print('"Burning in" unbiased sampler for approximately {:.3}ps...'.format(
+            (self.burn_in_length * self.timestep * self.steps_per_hmc).value_in_unit(unit.picoseconds)))
         for _ in tqdm(range(self.burn_in_length)):
             self.unbiased_simulation.step(1)
         print("Burn-in XC-GHMC acceptance rate: {:.3f}%".format(100 * self.get_acceptance_rate()))

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -222,8 +222,8 @@ class NonequilibriumSimulator(BookkeepingSimulator):
             if store_potential_energy:
                 potential_energies = [get_potential()]
             if store_W_shad_trace:
-                total_energies = [get_energy()]
-                heats = [get_heat()]
+                total_energies = [E_0]
+                heats = [Q_0]
                 W_shad_trace = []
             for _ in range(n_steps):
                 self.simulation.step(1)

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -226,11 +226,11 @@ class NonequilibriumSimulator(BookkeepingSimulator):
                     heats.append(get_heat())
                     DeltaE = total_energies[-1] - total_energies[-2]
                     DeltaQ = heats[-1] - heats[-2]
-                    W_shad_trace.append(DeltaE - DeltaQ)
+                    W_shad_trace.append((DeltaE - DeltaQ) / self.equilibrium_simulator.kT)
             if store_potential_energy:
                 result["potential_energies"] = np.array(potential_energies)
             if store_W_shad_trace:
-                result["W_shad_trace"] = np.array(W_shad_trace) / self.equilibrium_simulator.kT
+                result["W_shad_trace"] = np.array(W_shad_trace)
         else:
             self.simulation.step(n_steps)
 

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -230,7 +230,7 @@ class NonequilibriumSimulator(BookkeepingSimulator):
             if store_potential_energy:
                 result["potential_energies"] = np.array(potential_energies)
             if store_W_shad_trace:
-                result["W_shad_trace"] = np.array(W_shad_trace)
+                result["W_shad_trace"] = np.array(W_shad_trace) / self.equilibrium_simulator.kT
         else:
             self.simulation.step(n_steps)
 

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -91,7 +91,7 @@ class EquilibriumSimulator():
         print("Collecting equilibrium samples for '%s'..." % self.name)
 
         self.unbiased_simulation = self.construct_unbiased_simulation()
-        set_positions(self.unbiased_simulation, pos)
+        set_positions(self.unbiased_simulation, self.positions)
         print("Minimizing...")
         self.unbiased_simulation.minimizeEnergy()
 

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -45,7 +45,7 @@ class BookkeepingSimulator():
 class EquilibriumSimulator():
     """Simulates a system at equilibrium."""
 
-    def __init__(self, platform, topology, system, positions, temperature, xcghmc_timestep,
+    def __init__(self, platform, topology, system, positions, temperature, timestep,
                  burn_in_length, n_samples, thinning_interval, name):
 
         self.platform = platform
@@ -53,7 +53,7 @@ class EquilibriumSimulator():
         self.system = system
         self.positions = positions
         self.temperature = temperature
-        self.xcghmc_timestep = xcghmc_timestep
+        self.timestep = timestep
         self.burn_in_length = burn_in_length
         self.n_samples = n_samples
         self.thinning_interval = thinning_interval
@@ -83,7 +83,7 @@ class EquilibriumSimulator():
         n_steps = 10
         return self.construct_simulation(
             XCGHMCIntegrator(temperature=self.temperature, steps_per_hmc=n_steps, extra_chances=15,
-                             steps_per_extra_hmc=n_steps, timestep=self.xcghmc_timestep), use_reference=use_reference)
+                             steps_per_extra_hmc=n_steps, timestep=self.timestep), use_reference=use_reference)
 
     def collect_equilibrium_samples(self):
         """Collect equilibrium samples, return as (n_samples, n_atoms, 3) numpy array"""
@@ -96,7 +96,7 @@ class EquilibriumSimulator():
         self.unbiased_simulation.minimizeEnergy()
 
         print('"Burning in" unbiased sampler for {:.3}ps...'.format(
-            (self.burn_in_length * self.xcghmc_timestep * 10).value_in_unit(unit.picoseconds)))
+            (self.burn_in_length * self.timestep * 10).value_in_unit(unit.picoseconds)))
         for _ in tqdm(range(self.burn_in_length)):
             self.unbiased_simulation.step(1)
         print("Burn-in XC-GHMC acceptance rate: {:.3f}%".format(100 * self.get_acceptance_rate()))

--- a/benchmark/testsystems/bookkeepers.py
+++ b/benchmark/testsystems/bookkeepers.py
@@ -81,7 +81,7 @@ class EquilibriumSimulator():
 
     def construct_unbiased_simulation(self, use_reference=False):
         n_steps = 10
-        self.construct_simulation(
+        return self.construct_simulation(
             XCGHMCIntegrator(temperature=self.temperature, steps_per_hmc=n_steps, extra_chances=15,
                              steps_per_extra_hmc=n_steps, timestep=self.xcghmc_timestep), use_reference=use_reference)
 
@@ -96,7 +96,7 @@ class EquilibriumSimulator():
         self.unbiased_simulation.minimizeEnergy()
 
         print('"Burning in" unbiased sampler for {:.3}ps...'.format(
-            (self.burn_in_length * self.xcghmc_timestep * n_steps).value_in_unit(unit.picoseconds)))
+            (self.burn_in_length * self.xcghmc_timestep * 10).value_in_unit(unit.picoseconds)))
         for _ in tqdm(range(self.burn_in_length)):
             self.unbiased_simulation.step(1)
         print("Burn-in XC-GHMC acceptance rate: {:.3f}%".format(100 * self.get_acceptance_rate()))

--- a/benchmark/testsystems/coupled_power_oscillators.py
+++ b/benchmark/testsystems/coupled_power_oscillators.py
@@ -142,6 +142,6 @@ top, sys, pos = testsystem.topology, testsystem.system, testsystem.positions
 coupled_power_oscillators = EquilibriumSimulator(platform=configure_platform("CPU"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=1000, n_samples=n_samples,
                                            thinning_interval=10, name="coupled_power_oscillators")

--- a/benchmark/testsystems/coupled_power_oscillators.py
+++ b/benchmark/testsystems/coupled_power_oscillators.py
@@ -142,6 +142,6 @@ top, sys, pos = testsystem.topology, testsystem.system, testsystem.positions
 coupled_power_oscillators = EquilibriumSimulator(platform=configure_platform("CPU"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1.0 * unit.femtosecond,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
                                            burn_in_length=1000, n_samples=n_samples,
                                            thinning_interval=10, name="coupled_power_oscillators")

--- a/benchmark/testsystems/testsystems.py
+++ b/benchmark/testsystems/testsystems.py
@@ -74,11 +74,10 @@ def load_dhfr_reaction_field(constrained=True):
 
     return topology, system, positions
 
-temperature = simulation_parameters["temperature"]
 n_samples = 1000
-default_thinning = 10000
-burn_in_length = 1000000
-default_timestep = 0.5 * unit.femtosecond
+default_thinning = 1000
+burn_in_length = 10000
+default_timestep = 0.25 * unit.femtosecond
 from benchmark.testsystems.bookkeepers import EquilibriumSimulator
 
 def construct_simulator(name, top, sys, pos, timestep=default_timestep,
@@ -86,21 +85,21 @@ def construct_simulator(name, top, sys, pos, timestep=default_timestep,
     return EquilibriumSimulator(platform=configure_platform("CUDA"),
                          topology=top, system=sys, positions=pos,
                          temperature=temperature,
-                         ghmc_timestep=timestep,
+                         xcghmc_timestep=timestep,
                          burn_in_length=burn_in_length, n_samples=n_samples,
                          thinning_interval=thinning_interval, name=name)
 
 # DHFR
 dhfr_constrained = construct_simulator("dhfr_constrained", *load_dhfr_explicit(constrained=True))
 top, sys, pos = load_dhfr_explicit(constrained=False)
-dhfr_unconstrained = construct_simulator("dhfr_unconstrained", top, sys, pos, default_timestep / 10, default_thinning * 5)
+dhfr_unconstrained = construct_simulator("dhfr_unconstrained", top, sys, pos, default_timestep / 2.5, default_thinning * 2.5)
 
 # DHFR reaction field (for the MTS experiment)
 dhfr_reaction_field = construct_simulator("dhfr_constrained_reaction_field", *load_dhfr_reaction_field(constrained=True))
 
 # Src explicit
 top, sys, pos = load_src_explicit(constrained=True)
-src_constrained = construct_simulator("src_constrained", top, sys, pos, default_timestep, int(default_thinning / 10))
+src_constrained = construct_simulator("src_constrained", top, sys, pos, default_timestep / 2.5, default_thinning * 2.5)
 
 # T4 lysozyme
 t4_constrained = construct_simulator("t4_constrained", *load_t4_implicit(constrained=True))
@@ -111,6 +110,6 @@ top, sys, pos = load_constraint_coupled_harmonic_oscillators(constrained=True)
 constraint_coupled_harmonic_oscillators = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1000.0 * unit.femtosecond,
+                                           xcghmc_timestep=1000.0 * unit.femtosecond,
                                            burn_in_length=50, n_samples=10000,
                                            thinning_interval=10, name="constraint_coupled_harmonic_oscillators")

--- a/benchmark/testsystems/testsystems.py
+++ b/benchmark/testsystems/testsystems.py
@@ -85,7 +85,7 @@ def construct_simulator(name, top, sys, pos, timestep=default_timestep,
     return EquilibriumSimulator(platform=configure_platform("CUDA"),
                          topology=top, system=sys, positions=pos,
                          temperature=temperature,
-                         xcghmc_timestep=timestep,
+                         timestep=timestep,
                          burn_in_length=burn_in_length, n_samples=n_samples,
                          thinning_interval=thinning_interval, name=name)
 
@@ -110,6 +110,6 @@ top, sys, pos = load_constraint_coupled_harmonic_oscillators(constrained=True)
 constraint_coupled_harmonic_oscillators = EquilibriumSimulator(platform=configure_platform("Reference"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1000.0 * unit.femtosecond,
+                                           timestep=1000.0 * unit.femtosecond,
                                            burn_in_length=50, n_samples=10000,
                                            thinning_interval=10, name="constraint_coupled_harmonic_oscillators")

--- a/benchmark/testsystems/testsystems.py
+++ b/benchmark/testsystems/testsystems.py
@@ -69,7 +69,7 @@ def load_dhfr_reaction_field(constrained=True):
     topology, system, positions = testsystem.topology, testsystem.system, testsystem.positions
 
     keep_only_some_forces(system)
-    system = replace_reaction_field(system)
+    system = replace_reaction_field(system, shifted=True)
     add_barostat(system)
 
     return topology, system, positions

--- a/benchmark/testsystems/waterbox.py
+++ b/benchmark/testsystems/waterbox.py
@@ -19,7 +19,7 @@ top, sys, pos = load_waterbox(constrained=True)
 waterbox_constrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=1.0 * unit.femtosecond,
+                                           timestep=1.0 * unit.femtosecond,
                                            burn_in_length=100000, n_samples=1000,
                                            thinning_interval=10000, name="waterbox_constrained")
 
@@ -27,6 +27,6 @@ top, sys, pos = load_waterbox(constrained=False)
 flexible_waterbox = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           xcghmc_timestep=0.5 * unit.femtosecond,
+                                           timestep=0.5 * unit.femtosecond,
                                            burn_in_length=200000, n_samples=1000,
                                            thinning_interval=20000, name="flexible_waterbox")

--- a/benchmark/testsystems/waterbox.py
+++ b/benchmark/testsystems/waterbox.py
@@ -19,7 +19,7 @@ top, sys, pos = load_waterbox(constrained=True)
 waterbox_constrained = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=1.0 * unit.femtosecond,
+                                           xcghmc_timestep=1.0 * unit.femtosecond,
                                            burn_in_length=100000, n_samples=1000,
                                            thinning_interval=10000, name="waterbox_constrained")
 
@@ -27,6 +27,6 @@ top, sys, pos = load_waterbox(constrained=False)
 flexible_waterbox = EquilibriumSimulator(platform=configure_platform("CUDA"),
                                            topology=top, system=sys, positions=pos,
                                            temperature=temperature,
-                                           ghmc_timestep=0.5 * unit.femtosecond,
+                                           xcghmc_timestep=0.5 * unit.femtosecond,
                                            burn_in_length=200000, n_samples=1000,
                                            thinning_interval=20000, name="flexible_waterbox")

--- a/benchmark/utilities/openmm_utilities.py
+++ b/benchmark/utilities/openmm_utilities.py
@@ -31,8 +31,8 @@ def get_velocities(simulation):
 def set_positions(simulation, x, box_vectors=None):
     """Set particle positions, and optionally box_vectors"""
     simulation.context.setPositions(x)
-    if box_vectors != None:
-        simulation.context.setPeriodicBoxVectors(box_vectors)
+    if type(box_vectors) != type(None):
+        simulation.context.setPeriodicBoxVectors(*box_vectors)
 
 
 def set_velocities(simulation, v):

--- a/benchmark/utilities/openmm_utilities.py
+++ b/benchmark/utilities/openmm_utilities.py
@@ -28,9 +28,11 @@ def get_velocities(simulation):
     return simulation.context.getState(getVelocities=True).getVelocities(asNumpy=True)
 
 
-def set_positions(simulation, x):
-    """Set particle positions"""
+def set_positions(simulation, x, box_vectors=None):
+    """Set particle positions, and optionally box_vectors"""
     simulation.context.setPositions(x)
+    if box_vectors != None:
+        simulation.context.setPeriodicBoxVectors(box_vectors)
 
 
 def set_velocities(simulation, v):


### PR DESCRIPTION
Machinery for comparing the near-equilibrium estimator vs nested monte carlo estimators of an exact expression for the KL divergence. Since there is monte carlo in both an inner loop and outer loop, the second estimator will in general be biased unless the number of inner loop samples goes to infinity. However, the extent of this bias may be small in most cases. Implementing John's offline suggestions, this supports adaptive allocation of computational effort to meet a target uncertainty threshold on either loop independently, which should hopefully achieve a good trade-off between expense and bias.

Also contains some of the fixes / improvements that were sitting around on other branches or locally (addressing box vector bug, storing samples in .h5 instead of .npy, addressing unit bug).

Before review, I still want to:
- [x] Add my LSF scripts
- [ ] Add the plotting / post-processing code from my notebooks
- [x] Improve documentation
- [x] Refactor the repeated structure in the adaptive loops